### PR TITLE
add missing class property

### DIFF
--- a/src/CGD_EDDSL_Magic.php
+++ b/src/CGD_EDDSL_Magic.php
@@ -23,6 +23,7 @@ class CGD_EDDSL_Magic {
 	var $url; // plugin host site URL for EDD SL
 	var $version; // plugin version for EDD SL
 	var $name; // plugin name for EDD SL
+	var $author; // plugin author for EDD SL
 	var $key_statuses; // store list of key statuses and messages
 	var $bad_key_statuses; // store list of key statuses and messages
 	var $activate_errors; // store list of activation errors and error messages


### PR DESCRIPTION
This fixes PHP 8.2+ emitting a "deprecated" notice: "Creation of dynamic property CGD_EDDSL_Magic::$author is deprecated"